### PR TITLE
Update to new repo URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-Please follow Zim's [code style guidelines](https://github.com/Eriner/zim/wiki/Code-Style-Guide).
+Please follow Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ZIM - Zsh IMproved
 ==================
 
 <div align="center">
-  <a href="https://github.com/Eriner/zim">
+  <a href="https://github.com/zimfw/zimfw">
     <img width=650px src="https://i.eriner.me/zim_banner.png">
   </a>
 </div>
@@ -42,7 +42,7 @@ Installing Zim is easy. If you have a different shell framework installed (like 
 
 1. In a Zsh shell, clone the repository:
   ```
-  git clone --recursive https://github.com/Eriner/zim.git ${ZDOTDIR:-${HOME}}/.zim
+  git clone --recursive https://github.com/zimfw/zimfw.git ${ZDOTDIR:-${HOME}}/.zim
   ```
 
 2. Paste this into your terminal to prepend the initialization templates to your configs:
@@ -98,7 +98,7 @@ zmanage remove
 
 [fish_shell]: https://i.eriner.me/zim_history-substring-search.gif
 [syntax_highlighting]: https://i.eriner.me/zim_syntax-highlighting.gif
-[speed]: https://github.com/Eriner/zim/wiki/Speed
-[modules]: https://github.com/Eriner/zim/wiki/Modules
-[themes]: https://github.com/Eriner/zim/wiki/Themes
-[meta-module]: https://github.com/Eriner/zim/tree/master/modules/meta
+[speed]: https://github.com/zimfw/zimfw/wiki/Speed
+[modules]: https://github.com/zimfw/zimfw/wiki/Modules
+[themes]: https://github.com/zimfw/zimfw/wiki/Themes
+[meta-module]: https://github.com/zimfw/zimfw/tree/master/modules/meta

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -5,10 +5,10 @@ Allows for fish shell-like searching of history with UP and DOWN.
 
 ![example][fish_shell]
 
-This module requires the [input](https://github.com/Eriner/zim/blob/master/modules/input/README.md) module. Without it, you may experience odd behavior.
+This module requires the [input](https://github.com/zimfw/zimfw/blob/master/modules/input/README.md) module. Without it, you may experience odd behavior.
 Put 'input' in the first line and 'history-substring-search' on the second line of `zmodules` in your `.zimrc`.
 
-Additionally, if you use [syntax-highlighting](https://github.com/Eriner/zim/blob/master/modules/syntax-highlighting/README.md), place 'syntax-highlighting' before 'history-substring-search' on the second line of `zmodules` in your `.zimrc`.
+Additionally, if you use [syntax-highlighting](https://github.com/zimfw/zimfw/blob/master/modules/syntax-highlighting/README.md), place 'syntax-highlighting' before 'history-substring-search' on the second line of `zmodules` in your `.zimrc`.
 
 The options set explicitly by init.zsh are the default options, and are only set for consistancy.
 

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -3,7 +3,7 @@ Prompt
 
 Initializes and provides customizable prompt themes.
 
-Images of various prompt themes can be found on the [wiki](https://github.com/Eriner/zim/wiki/Themes).
+Images of various prompt themes can be found on the [wiki](https://github.com/zimfw/zimfw/wiki/Themes).
 
 A list of available prompts can be found by running `prompt -l`.
 

--- a/modules/prompt/themes/magicmace.zsh-theme
+++ b/modules/prompt/themes/magicmace.zsh-theme
@@ -2,7 +2,7 @@
 # magicmace theme
 # Ideas and code taken from:
 #   xero's zsh prompt <http://code.xero.nu/dotfiles>
-#   eriner's eriner prompt <https://github.com/Eriner/zim/blob/master/modules/prompt/themes/eriner.zsh-theme>
+#   eriner's eriner prompt <https://github.com/zimfw/zimfw/blob/master/modules/prompt/themes/eriner.zsh-theme>
 #
 # Requires the `git-info` zmodule to be included in the .zimrc file.
 

--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -5,7 +5,7 @@ Adds fish shell-like [syntax highlighting](https://github.com/zsh-users/zsh-synt
 
 ![syntax-highlighting][syntax_highlighting]
 
-If you are also using [history-substring-search](https://github.com/Eriner/zim/blob/master/modules/history-substring-search/README.md), 
+If you are also using [history-substring-search](https://github.com/zimfw/zimfw/blob/master/modules/history-substring-search/README.md), 
 ensure you have placed 'syntax-highlighting' before 'history-substring-search' on the second line of `zmodules` in your `.zimrc`.
 
 .zimrc Configuration

--- a/tools/zim_issue
+++ b/tools/zim_issue
@@ -16,7 +16,7 @@ waiter_func() {
 
 # print init dialog
 print "Please check the existing issues to make sure you\'re not duplicating a report"
-print "https://github.com/Eriner/zim/issues"
+print "https://github.com/zimfw/zimfw/issues"
 
 # if they don't accept, bail
 if ! waiter_func; then


### PR DESCRIPTION
I know the old URL redirects, but it might not do forever, so I replaced all the occurances or `Eriner/zim` with the new `zimfw/zimfw`. I think I found all the places.