### PR TITLE
Compile functions.zwc for each functions directory

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -20,7 +20,7 @@ fi
   setopt LOCAL_OPTIONS EXTENDED_GLOB
 
   # autoload searches fpath for function locations; add enabled module function paths
-  fpath=(${ZIM_HOME}/functions.zwc ${ZIM_HOME}/modules/prompt/functions ${fpath})
+  [[ -n ${zmodules} ]] && fpath=(${ZIM_HOME}/modules/${^zmodules}/functions(/FN) ${fpath})
 
   for mod_function in ${ZIM_HOME}/modules/${^zmodules}/functions/^([_.]*|prompt_*_setup|README*|*.zwc|*.zwc.old)(-.N:t); do
     autoload -Uz ${mod_function}

--- a/login_init.zsh
+++ b/login_init.zsh
@@ -8,8 +8,7 @@
 #
 
 (
-  local file
-  local zmodule
+  local dir file
   setopt LOCAL_OPTIONS EXTENDED_GLOB
   autoload -U zrecompile
 
@@ -20,11 +19,13 @@
   zrecompile -pq ${ZDOTDIR:-${HOME}}/.zshrc
 
   # zcompile enabled module autoloaded functions
-  zrecompile -pq ${ZIM_HOME}/functions ${ZIM_HOME}/modules/${^zmodules}/functions/^([_.]*|prompt_*_setup|README*|*.zwc|*.zwc.old)(-.N)
+  for dir in ${ZIM_HOME}/modules/${^zmodules}/functions(/FN); do
+    zrecompile -pq ${dir}.zwc ${dir}/^([_.]*|prompt_*_setup|README*|*.zwc|*.zwc.old)(-.N)
+  done
 
   # zcompile enabled module init scripts
-  for zmodule (${zmodules}); do
-    zrecompile -pq ${ZIM_HOME}/modules/${zmodule}/init.zsh
+  for file in ${ZIM_HOME}/modules/${^zmodules}/init.zsh(-.N); do
+    zrecompile -pq ${file}
   done
 
   # zcompile all prompt setup scripts


### PR DESCRIPTION
instead of a big single `functions.zwc` file containing functions from all the `functions` subdirectories.

Having a big single digest file does reduce the number of OS file descriptors to 1, instead of:
* as many functions as are declared in enabled modules, what we had before commit 55df5a4
* as many enabled modules, as we have implemented in this commit

but it also raised bigger and still unsolved issues as #231, #232, and #234.

This solution here better suits the functions autoloading mechanism in zsh, as documented in http://zsh.sourceforge.net/Doc/Release/Functions.html#index-autoloading-functions

Given `~/.zim/modules/foo/functions` is in the `fpath`, autoload looks for functions in the following files, picking the **newest one** in this order:
* `~/.zim/modules/foo/functions.zwc`, which should contain all functions in the directory named `functions`
* `~/.zim/modules/foo/functions/function.zwc`
* `~/.zim/modules/foo/functions/function`

A relevant change in this approach is also having individual entries back in `fpath` for the `functions` subdirectory of each enabled module (as was the case before commit 55df5a4). With this back, we don't need to worry anymore about being absolutely sure that all functions are zcompiled, thanks to the autoloading mechanism described above.

Fixes #231. Fixes #232. Closes #234.