### PR TITLE
Repair gCl alias

### DIFF
--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -50,7 +50,7 @@ alias gcS='git commit -S'
 alias gpS='git show --pretty=short --show-signature'
 
 # Conflict (C)
-alias gCl='git diff --diff-filter=U --name-only --no-pager'
+alias gCl='git --no-pager diff --diff-filter=U --name-only'
 alias gCa='git add $(gCl)'
 alias gCe='git mergetool $(gCl)'
 alias gCo='git checkout --ours --'


### PR DESCRIPTION
I noted that I got a `invalid option` error when trying to run the alias `gCl`. The issue with this alias is that the `no-pager` option was set on `git-diff` instead of `git`.