### PR TITLE
[completion] Ask when completion list is long

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -36,6 +36,9 @@ setopt PATH_DIRS
 # Make globbing (filename generation) not sensitive to case.
 unsetopt CASE_GLOB
 
+# Don't beep on an ambiguous completion.
+unsetopt LIST_BEEP
+
 
 #
 # completion module options

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -30,21 +30,11 @@ source ${0:h}/compdefs.zsh
 # the cursor is moved to the end of the word
 setopt ALWAYS_TO_END
 
-# Automatically use menu completion after the second consecutive request for completion
-setopt AUTO_MENU
-
-# Automatically list choices on an ambiguous completion. 
-setopt AUTO_LIST
-
 # Perform a path search even on command names with slashes in them.
 setopt PATH_DIRS
 
-# Make globbing (filename generation) sensitive to case.
+# Make globbing (filename generation) not sensitive to case.
 unsetopt CASE_GLOB
-
-# On an ambiguous completion, instead of listing possibilities or beeping, insert the first match immediately.
-# Then when completion is requested again, remove the first match and insert the second match, etc.
-unsetopt MENU_COMPLETE
 
 
 #
@@ -53,15 +43,14 @@ unsetopt MENU_COMPLETE
 
 # group matches and describe.
 zstyle ':completion:*:*:*:*:*' menu select
-zstyle ':completion:*:matches' group 'yes'
-zstyle ':completion:*:options' description 'yes'
+zstyle ':completion:*:matches' group yes
+zstyle ':completion:*:options' description yes
 zstyle ':completion:*:options' auto-description '%d'
-zstyle ':completion:*:corrections' format ' %F{green}-- %d (errors: %e) --%f'
-zstyle ':completion:*:descriptions' format ' %F{yellow}-- %d --%f'
-zstyle ':completion:*:messages' format ' %F{purple} -- %d --%f'
-zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
-zstyle ':completion:*:default' list-prompt '%S%M matches%s'
-zstyle ':completion:*' format ' %F{yellow}-- %d --%f'
+zstyle ':completion:*:corrections' format '%F{green}-- %d (errors: %e) --%f'
+zstyle ':completion:*:descriptions' format '%F{yellow}-- %d --%f'
+zstyle ':completion:*:messages' format '%F{purple}-- %d --%f'
+zstyle ':completion:*:warnings' format '%F{red}-- no matches found --%f'
+zstyle ':completion:*' format '%F{yellow}-- %d --%f'
 zstyle ':completion:*' group-name ''
 zstyle ':completion:*' verbose yes
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'


### PR DESCRIPTION
To achieve this, we have to make sure that the following is not set:
* `zstyle ':completion:*:default' list-prompt '...'`

otherwise long completion lists will be paginated (without prompting).

Remove options being set that are already the default.

And remove the space character from the beginning of the messages.

Fixes #136