### PR TITLE
hard-fail on missing zshbuiltin is-at-least

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -2,7 +2,7 @@
 # Zim initializition
 #
 
-autoload -Uz is-at-least
+autoload -UzR is-at-least
 if ! is-at-least 5.2; then
   print "ERROR: Zim didn't start. You're using zsh version ${ZSH_VERSION}, and versions < 5.2 are not supported. Update your zsh." >&2
   return 1


### PR DESCRIPTION
From `man zshbuiltins`:

with -R, an error message is printed and command processing aborted
immediately the search fails, i.e. at the autoload command rather
than at function execution..

Fixes #249
