### PR TITLE
[input] Use custom expand-or-complete in zsh < 5.3

### DIFF
--- a/modules/input/init.zsh
+++ b/modules/input/init.zsh
@@ -102,14 +102,16 @@ if [[ -n "${key_info[BackTab]}" ]]; then
   bindkey "${key_info[BackTab]}" reverse-menu-complete
 fi
 
-# Redisplay after completing, and avoid blank prompt after <Tab><Tab><Ctrl-C>
-expand-or-complete-with-redisplay() {
-  print -n '...'
-  zle expand-or-complete
-  zle redisplay
-}
-zle -N expand-or-complete-with-redisplay
-bindkey "${key_info[Control]}I" expand-or-complete-with-redisplay
+autoload -Uz is-at-least && if ! is-at-least 5.3; then
+  # Redisplay after completing, and avoid blank prompt after <Tab><Tab><Ctrl-C>
+  expand-or-complete-with-redisplay() {
+    print -Pn '...'
+    zle expand-or-complete
+    zle redisplay
+  }
+  zle -N expand-or-complete-with-redisplay
+  bindkey "${key_info[Control]}I" expand-or-complete-with-redisplay
+fi
 
 # Put into application mode and validate ${terminfo}
 zle-line-init() {


### PR DESCRIPTION
as `expand-or-complete-with-redisplay` was added to fix an issue reported with zsh 5.2 when completing with <Tab><Tab><Ctrl-C>. See #85.

Fixes #134