### PR TITLE
[Initialization] ZCompile all plugin *.zsh files and load init.sh plugins

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -36,7 +36,7 @@ fi
     if [[ ! -d ${zmodule_dir} ]]; then
       print "No such module \"${zmodule}\"." >&2
     else
-      for zmodule_file (${zmodule_dir}/init.zsh \
+      for zmodule_file (${zmodule_dir}/init.{zsh,sh} \
           ${zmodule_dir}/{,zsh-}${zmodule}.{zsh,plugin.zsh,zsh-theme,sh}); do
         if [[ -f ${zmodule_file} ]]; then
           source ${zmodule_file}

--- a/login_init.zsh
+++ b/login_init.zsh
@@ -28,8 +28,8 @@
   for zmodule (${zmodules}); do
     zmodule_dir=${ZIM_HOME}/modules/${zmodule}
     if [[ -d ${zmodule_dir} ]]; then
-      for file (${zmodule_dir}/**/*.{zsh,sh} \
-          ${zmodule_dir}/*.{zsh,sh}); do
+      for file (${zmodule_dir}/**/*.{zsh,sh,zsh-theme} \
+          ${zmodule_dir}/*.{zsh,sh,zsh-theme}); do
         if [[ -f ${file} ]]; then
           zrecompile -pq ${file}
         fi

--- a/login_init.zsh
+++ b/login_init.zsh
@@ -29,7 +29,7 @@
     zmodule_dir=${ZIM_HOME}/modules/${zmodule}
     if [[ -d ${zmodule_dir} ]]; then
       for file (${zmodule_dir}/**/*.{zsh,sh} \
-            ${zmodule_dir}/*.{zsh,sh}); do
+          ${zmodule_dir}/*.{zsh,sh}); do
         if [[ -f ${file} ]]; then
           zrecompile -pq ${file}
         fi

--- a/login_init.zsh
+++ b/login_init.zsh
@@ -23,32 +23,23 @@
     zrecompile -pq ${dir}.zwc ${dir}/^([_.]*|prompt_*_setup|README*|*.zwc|*.zwc.old)(-.N)
   done
 
-  # zcompile enabled module init scripts
+  # zcompile enabled module init scripts and subdirs
+  setopt nullglob
   for zmodule (${zmodules}); do
     zmodule_dir=${ZIM_HOME}/modules/${zmodule}
     if [[ -d ${zmodule_dir} ]]; then
-      for file (${zmodule_dir}/init.zsh \
-          ${zmodule_dir}/{,zsh-}${zmodule}.{zsh,plugin.zsh,zsh-theme,sh}); do
+      for file (${zmodule_dir}/**/*.{zsh,sh} \
+            ${zmodule_dir}/*.{zsh,sh}); do
         if [[ -f ${file} ]]; then
           zrecompile -pq ${file}
-          break
         fi
       done
     fi
   done
-
+  unsetopt nullglob
   # zcompile all prompt setup scripts
   for file in ${ZIM_HOME}/modules/prompt/functions/prompt_*_setup; do
     zrecompile -pq ${file}
   done
-
-  # syntax-highlighting
-  for file in ${ZIM_HOME}/modules/syntax-highlighting/external/highlighters/**^test-data/*.zsh; do
-    zrecompile -pq ${file}
-  done
-  zrecompile -pq ${ZIM_HOME}/modules/syntax-highlighting/external/zsh-syntax-highlighting.zsh
-
-  # zsh-histery-substring-search
-  zrecompile -pq ${ZIM_HOME}/modules/history-substring-search/external/zsh-history-substring-search.zsh
-
+  
 ) &!


### PR DESCRIPTION
Updated `login_init.zsh` to zcompile all patterns matching `{Plugin-dir}/**/*.{zsh,sh}` and `{Plugin-dir}/*.{zsh,sh}`.
Along with a minor change, to also load `init.sh` plugins.
This allows us to remove external plugin overrides and increase speed, along with greater compatibility with plugins like [enhancd](https://github.com/b4b4r07/enhancd) which use `init.sh` rather than `init.zsh`.