### PR TITLE
Fix for a small bug with vi mode and history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Installing Zim is easy. If you have a different shell framework installed (like 
   source ${ZDOTDIR:-${HOME}}/.zlogin
   ```
 
-5. You're done! Enjoy your Zsh IMproved! Take some time to read about the [available modules][modules] and tweak your `.zshrc` file. To set vi mode, set `zinput_mode` in `.zimrc`.
+5. You're done! Enjoy your Zsh IMproved! Take some time to read about the [available modules][modules] and tweak your `.zshrc` file. To set input mode, set `zinput_mode` in `.zimrc`.
 
 Updating
 --------

--- a/init.zsh
+++ b/init.zsh
@@ -14,8 +14,8 @@ fi
 # Source user configuration
 [[ -s ${ZDOTDIR:-${HOME}}/.zimrc ]] && source ${ZDOTDIR:-${HOME}}/.zimrc
 
-# If necessary, set vi mode before loading modules
-if ${zinput_mode}='vi'; then
+# If necessary, set vi mode before loading modules to ensure history search with arrow keys works in vi mode
+if [ ${zinput_mode}='vi' ]; then
   set -o vi
 else
   set -o emacs

--- a/init.zsh
+++ b/init.zsh
@@ -15,7 +15,7 @@ fi
 [[ -s ${ZDOTDIR:-${HOME}}/.zimrc ]] && source ${ZDOTDIR:-${HOME}}/.zimrc
 
 # If necessary, set vi mode before loading modules
-if zinput_mode='vi'; then
+if ${zinput_mode}='vi'; then
   set -o vi
 else
   set -o emacs

--- a/init.zsh
+++ b/init.zsh
@@ -14,6 +14,11 @@ fi
 # Source user configuration
 [[ -s ${ZDOTDIR:-${HOME}}/.zimrc ]] && source ${ZDOTDIR:-${HOME}}/.zimrc
 
+if zinput_mode='emacs'; then
+  set -o emacs
+else
+  set -o vi
+
 # Autoload module functions
 () {
   local mod_function

--- a/init.zsh
+++ b/init.zsh
@@ -14,10 +14,12 @@ fi
 # Source user configuration
 [[ -s ${ZDOTDIR:-${HOME}}/.zimrc ]] && source ${ZDOTDIR:-${HOME}}/.zimrc
 
-if zinput_mode='emacs'; then
-  set -o emacs
-else
+# If necessary, set vi mode before loading modules
+if zinput_mode='vi'; then
   set -o vi
+else
+  set -o emacs
+fi
 
 # Autoload module functions
 () {

--- a/templates/zimrc
+++ b/templates/zimrc
@@ -12,7 +12,7 @@
 # The second line of modules may depend on options set by modules in the first
 # line. These dependencies are noted on the respective module's README.md.
 zmodules=(directory environment git git-info history input utility custom \
-          syntax-highlighting history-substring-search prompt completion)
+          syntax-highlighting prompt completion history-substring-search)
 
 
 ###################

--- a/templates/zimrc
+++ b/templates/zimrc
@@ -27,13 +27,6 @@ zmodules=(directory environment git git-info history input utility custom \
 zprompt_theme='steeef'
 
 #
-# Input
-#
-
-# Set to vi or emacs
-zinput_mode='emacs'
-
-#
 # Completion
 #
 
@@ -63,6 +56,9 @@ ztermtitle='%n@%m:%~'
 #
 # Input
 #
+
+# Set to vi or emacs
+zinput_mode='emacs'
 
 # Uncomment to enable double-dot expansion.
 # This appends '../' to your input for each '.' you type after an initial '..'

--- a/templates/zimrc
+++ b/templates/zimrc
@@ -27,6 +27,13 @@ zmodules=(directory environment git git-info history input utility custom \
 zprompt_theme='steeef'
 
 #
+# Input
+#
+
+# Set to vi or emacs
+zinput_mode='emacs'
+
+#
 # Completion
 #
 


### PR DESCRIPTION
As per [this bug](https://github.com/zimfw/zimfw/issues/258), and possibly [this](https://github.com/zimfw/zimfw/issues/114), setting vi mode after initializing overwrites up and down arrow keys, disabling history substring search. The workaround was to move `history-substring-search` to the end of `zmodules` and  set the mode before loading zim in `.zshrc`, which is counterintuitive and, IMO, a bad habit. Instead, I've added a setting to `.zimrc` read by `init.zsh` that fixes that. I think prezto did something similar. Also modified readme to point out the new way to set editing mode. 