### PR TITLE
[Completion] Setopt GLOB_COMPLETE

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -30,6 +30,9 @@ source ${0:h}/compdefs.zsh
 # the cursor is moved to the end of the word
 setopt ALWAYS_TO_END
 
+# Glob completions
+setopt GLOB_COMPLETE
+
 # Perform a path search even on command names with slashes in them.
 setopt PATH_DIRS
 


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/O6q9zYTMtPwH8vfsfBt19GFje.png)](https://asciinema.org/a/O6q9zYTMtPwH8vfsfBt19GFje)
Fixes #212.
```
GLOB_COMPLETE
When the current word has a glob pattern, do not insert all the words resulting from the expansion but generate matches as for completion and cycle through them like MENU_COMPLETE.
The matches are generated as if a '*' was added to the end of the word, or inserted at the cursor when COMPLETE_IN_WORD is set. 
This actually uses pattern matching, not globbing, so it works not only for files but for any completion, such as options, user names, etc.
Note that when the pattern matcher is used, matching control (for example, case-insensitive or anchored matching) cannot be used. 
This limitation only applies when the current word contains a pattern; simply turning on the GLOB_COMPLETE option does not have this effect.
```