### PR TITLE
Unify the `for` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Installing Zim is easy. If you have a different shell framework installed (like 
 2. Paste this into your terminal to prepend the initialization templates to your configs:
   ```
   setopt EXTENDED_GLOB
-  for template_file ( ${ZDOTDIR:-${HOME}}/.zim/templates/* ); do
+  for template_file in ${ZDOTDIR:-${HOME}}/.zim/templates/*; do
     user_file="${ZDOTDIR:-${HOME}}/.${template_file:t}"
     touch ${user_file}
     ( print -rn "$(<${template_file})$(<${user_file})" >! ${user_file} ) 2>/dev/null

--- a/init.zsh
+++ b/init.zsh
@@ -37,13 +37,13 @@ fi
 () {
   local zmodule zmodule_dir zmodule_file
 
-  for zmodule (${zmodules}); do
+  for zmodule in ${zmodules}; do
     zmodule_dir=${ZIM_HOME}/modules/${zmodule}
     if [[ ! -d ${zmodule_dir} ]]; then
       print "No such module \"${zmodule}\"." >&2
     else
-      for zmodule_file (${zmodule_dir}/init.zsh \
-          ${zmodule_dir}/{,zsh-}${zmodule}.{zsh,plugin.zsh,zsh-theme,sh}); do
+      for zmodule_file in ${zmodule_dir}/init.zsh \
+          ${zmodule_dir}/{,zsh-}${zmodule}.{zsh,plugin.zsh,zsh-theme,sh}; do
         if [[ -f ${zmodule_file} ]]; then
           source ${zmodule_file}
           break

--- a/login_init.zsh
+++ b/login_init.zsh
@@ -22,7 +22,7 @@
   done
 
   # zcompile enabled module scripts
-  for file (${ZIM_HOME}/modules/${^zmodules}/(^*test*/)#*.zsh{,-theme}(.NLk+1)); do
+  for file in ${ZIM_HOME}/modules/${^zmodules}/(^*test*/)#*.zsh{,-theme}(.NLk+1); do
     zrecompile -pq ${file}
   done
 

--- a/modules/git/functions/git-branch-delete-interactive
+++ b/modules/git/functions/git-branch-delete-interactive
@@ -10,7 +10,5 @@ if command git branch --delete ${@} && \
     read -q "?Also delete remote branch(es) ${remotes} [y/N]? "; then
   print
   local remote
-  for remote (${remotes}); do
-    command git push ${remote%%/*} :${remote#*/}
-  done
+  for remote (${remotes}) command git push ${remote%%/*} :${remote#*/}
 fi

--- a/modules/git/functions/git-ignore-add
+++ b/modules/git/functions/git-ignore-add
@@ -3,6 +3,4 @@ local git_root
 git_root=$(git-root) || return 1
 
 # we are in a git repository. add parameters to .gitignore
-for file in "${@}"; do
-  print "${file}" >>! "${git_root}/.gitignore"
-done
+for file (${@}) print ${file} >>! "${git_root}/.gitignore"

--- a/modules/input/init.zsh
+++ b/modules/input/init.zsh
@@ -46,12 +46,8 @@ key_info=(
 # Bind the keys
 
 local key
-for key in "${(s: :)key_info[ControlLeft]}"; do
-  bindkey ${key} backward-word
-done
-for key in "${(s: :)key_info[ControlRight]}"; do
-  bindkey ${key} forward-word
-done
+for key (${(s: :)key_info[ControlLeft]}) bindkey ${key} backward-word
+for key (${(s: :)key_info[ControlRight]}) bindkey ${key} forward-word
 
 [[ -n ${key_info[Home]} ]] && bindkey ${key_info[Home]} beginning-of-line
 [[ -n ${key_info[End]} ]] && bindkey ${key_info[End]} end-of-line

--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -126,7 +126,7 @@ alias pacblame="${zpacman_frontend} -Qo"
 #
 
 # source helper functions/aliases
-for helper ( ${zpacman_helper[@]} ); do
+for helper in ${zpacman_helper[@]}; do
   if [[ -s ${0:h}/helper_${helper}.zsh ]]; then
     source ${0:h}/helper_${helper}.zsh
   else


### PR DESCRIPTION
For short single commands, prefer a one-liner `for` with the zsh syntax:
```
for x (foo bar) print ${x}
```
Otherwise just place `; do` on the same line as the POSIX `for ... in`:
```
for x in foo bar; do
  print ${x}
done
```