### PR TITLE
[Completion] Allow completion to be loaded at an arbitrary location

### DIFF
--- a/modules/completion/README.md
+++ b/modules/completion/README.md
@@ -5,8 +5,6 @@ Enables and configures smart and extensive tab completion.
 
 Completions are sourced from [zsh-completions](https://github.com/zsh-users/zsh-completions).
 
-This should be the **LAST** module in the `zmodules` list in your `.zimrc`.
-
 Contributing
 ------------
 

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -59,6 +59,14 @@ zstyle ':completion:*' verbose yes
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
 
 # directories
+# If LS_COLORS is set, just use it
+if (( ${+LS_COLORS} )); then
+  # Set completion colors to LS_COLORS
+  zstyle ':completion:*' list-colors $LS_COLORS
+else
+  # Fallback to default LS_COLORS
+  zstyle ':completion:*' list-colors 'di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
+fi
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
 zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'expand'

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -59,7 +59,6 @@ zstyle ':completion:*' verbose yes
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
 
 # directories
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
 zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'expand'

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -59,13 +59,10 @@ zstyle ':completion:*' verbose yes
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
 
 # directories
-# If LS_COLORS is set, just use it
 if (( ${+LS_COLORS} )); then
-  # Set completion colors to LS_COLORS
-  zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
+  zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
 else
-  # Fallback to default LS_COLORS
-  zstyle ':completion:*' list-colors ${(s.:.)di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43}
+  zstyle ':completion:*:default' list-colors ${(s.:.)di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43}
 fi
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -62,10 +62,10 @@ zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
 # If LS_COLORS is set, just use it
 if (( ${+LS_COLORS} )); then
   # Set completion colors to LS_COLORS
-  zstyle ':completion:*' list-colors $LS_COLORS
+  zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
 else
   # Fallback to default LS_COLORS
-  zstyle ':completion:*' list-colors 'di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
+  zstyle ':completion:*' list-colors ${(s.:.)di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43}
 fi
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -12,9 +12,6 @@ if (( terminfo[colors] >= 8 )); then
   # GNU colours are used by completion module for all OSTYPEs
   (( ! ${+LS_COLORS} )) && export LS_COLORS='di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
 
-  # Set completion colors to LS_COLORS
-  zstyle ':completion:*' list-colors $LS_COLORS
-
   if (( ${+commands[dircolors]} )); then
     # GNU
 

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -12,6 +12,9 @@ if (( terminfo[colors] >= 8 )); then
   # GNU colours are used by completion module for all OSTYPEs
   (( ! ${+LS_COLORS} )) && export LS_COLORS='di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
 
+  # Set completion colors to LS_COLORS
+  zstyle ':completion:*' list-colors $LS_COLORS
+
   if (( ${+commands[dircolors]} )); then
     # GNU
 


### PR DESCRIPTION
Currently, if you move the location of completion to before utility, Zim doesn't set `list-colors` correctly. However, sometimes if you move the completion module to the end of the `zmodules` array, you sometimes end up with errors with compdefs (it doens't happen with Zim's native modules, but I still think we should have something in place).
So, if you need to move completion, you end up with a prompt like:
![Before](https://i.imgur.com/ezOi94W.png)
However, with the location changed, you then get:
![After](https://i.imgur.com/DmES38U.png)