### PR TITLE
pacman: add yay to SUID handling AUR helpers

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -24,8 +24,8 @@ elif (( ! ${+commands[${zpacman_frontend}]} )); then
 You can fix this error by editing the 'zpacman_frontend' variable in your .zimrc" >&2
   zpacman_frontend='pacman'
   zpacman_frontend_priv='sudo pacman'
-elif [[ ${zpacman_frontend} == ("yaourt"|"pacaur") ]]; then
-  # yaourt and pacaur handles SUID themselves
+elif [[ ${zpacman_frontend} == ("yaourt"|"pacaur"|"yay") ]]; then
+  # those AUR helpers handle SUID themselves
   zpacman_frontend_priv="${zpacman_frontend}"
 else
   zpacman_frontend_priv="sudo ${zpacman_frontend}"


### PR DESCRIPTION
Yay handles sudo calls themself, so add it to the list. There are probably other suid aware helpers, see the [Arch wiki page on aur helpers](https://wiki.archlinux.org/index.php/AUR_helpers).
