### PR TITLE
Add `homebrew` module

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -1,0 +1,30 @@
+Homebrew
+========
+
+Defines Homebrew aliases.
+
+Aliases
+-------
+
+### Homebrew
+
+  - `brewc` cleans outdated brews and their cached archives.
+  - `brewC` cleans outdated brews, including keg-only, and their cached archives.
+  - `brewi` installs a formula.
+  - `brewl` lists installed formulae.
+  - `brewo` lists brews which have an update available.
+  - `brews` searches for a formula or a cask.
+  - `brewu` updates and upgrades Homebrew packages and formulae.
+  - `brewx` uninstalls a formula.
+
+### Homebrew Cask
+
+  - `cask` is aliased to `brew cask`.
+  - `caskc` cleans up old cached downloads.
+  - `caskC` cleans up all cached downloads.
+  - `caski` installs a cask.
+  - `caskl` lists installed casks.
+  - `casko` lists casks which have an update available.
+  - `casks` print a message telling that `brew cask search` is deprecated.
+  - `caskx` uninstalls a cask.
+

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -1,0 +1,39 @@
+#
+# Defines Homebrew aliases.
+#
+# Authors:
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Qi Zhang <singularitti@outlook.com>
+#
+
+# Return if requirements are not found.
+if ! [[ "${OSTYPE}" =~ (darwin|linux)* ]]; then
+	return 1
+fi
+
+#
+# Aliases
+#
+
+# Homebrew
+alias brewc='brew cleanup'
+alias brewC='brew cleanup --force'
+alias brewi='brew install'
+alias brewl='brew list'
+alias brewo='brew outdated'
+alias brews='brew search'
+alias brewu='brew update && brew upgrade'
+alias brewx='brew remove'
+
+# Homebrew Cask
+alias cask='brew cask'
+alias caskc='brew cask cleanup --outdated'
+alias caskC='brew cask cleanup'
+alias caski='brew cask install'
+alias caskl='brew cask list'
+alias casko='brew cask outdated'
+alias caskx='brew cask uninstall'
+
+casks() {
+	print "Calling \`brew cask search\` is deprecated! Please use \`brews\` instead!"
+}

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -35,5 +35,5 @@ alias casko='brew cask outdated'
 alias caskx='brew cask uninstall'
 
 casks() {
-	print "Calling \`brew cask search\` is deprecated! Please use \`brews\` instead!"
+  print "Calling \`brew cask search\` is deprecated! Please use \`brews\` instead!"
 }


### PR DESCRIPTION
Originally forked from project [Prezto](https://github.com/sorin-ionescu/prezto) `homebrew` [module](https://github.com/sorin-ionescu/prezto/tree/master/modules/homebrew). Thanks to [Sorin Ionescu](https://github.com/sorin-ionescu) for the very first contribution!

I am not an expert of zsh, but I tried to fix minor "un"zsh style of the code in the [original code](https://github.com/sorin-ionescu/prezto/blob/0d6e7de0312366322bf7e7e1dbb41697b5bcd3b1/modules/homebrew/init.zsh#L9).
This module is simple and I would like to maintain it since I am a macOS user.