### PR TITLE
do not track new files in submodules from main repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,28 @@
 [submodule "modules/history-substring-search/external"]
 	path = modules/history-substring-search/external
 	url = https://github.com/zsh-users/zsh-history-substring-search.git
+	ignore = untracked
 [submodule "modules/completion/external"]
 	path = modules/completion/external
 	url = https://github.com/zsh-users/zsh-completions.git
+	ignore = untracked
 [submodule "modules/syntax-highlighting/external"]
 	path = modules/syntax-highlighting/external
 	url = https://github.com/zsh-users/zsh-syntax-highlighting.git
+	ignore = untracked
 [submodule "modules/prompt/external-themes/pure"]
 	path = modules/prompt/external-themes/pure
 	url = https://github.com/sindresorhus/pure.git
+	ignore = untracked
 [submodule "modules/prompt/external-themes/liquidprompt"]
 	path = modules/prompt/external-themes/liquidprompt
 	url = https://github.com/nojhan/liquidprompt.git
+	ignore = untracked
 [submodule "modules/prompt/external-themes/lean"]
 	path = modules/prompt/external-themes/lean
 	url = https://github.com/miekg/lean
+	ignore = untracked
 [submodule "modules/autosuggestions/external"]
 	path = modules/autosuggestions/external
 	url = https://github.com/zsh-users/zsh-autosuggestions.git
+	ignore = untracked


### PR DESCRIPTION
prevent main repository `git status` reporting submodules having new files
new files are usualy cimpiled zsh files
there is no way to .gitingore from main repository specific files in submodules

Please follow Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).
