### PR TITLE
Use cat to concatenate files in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,9 @@ Installing Zim is easy. If you have a different shell framework installed (like 
 
 2. Paste this into your terminal to prepend the initialization templates to your configs:
   ```
-  setopt EXTENDED_GLOB
   for template_file in ${ZDOTDIR:-${HOME}}/.zim/templates/*; do
     user_file="${ZDOTDIR:-${HOME}}/.${template_file:t}"
-    touch ${user_file}
-    ( print -rn "$(<${template_file})$(<${user_file})" >! ${user_file} ) 2>/dev/null
+    cat ${template_file} ${user_file}(.N) >! ${user_file}
   done
   ```
 

--- a/templates/zimrc
+++ b/templates/zimrc
@@ -1,5 +1,3 @@
-
-
 #################
 # CORE SETTINGS #
 #################
@@ -78,14 +76,12 @@ zinput_mode='emacs'
 # removing the 'cursor' highlighter will fix the disappearing cursor problem
 zhighlighters=(main brackets cursor)
 
-
 #
 # SSH
 #
 
 # Load these ssh identities with the ssh module
 #zssh_ids=(id_rsa)
-
 
 #
 # Pacman
@@ -96,3 +92,5 @@ zhighlighters=(main brackets cursor)
 
 # Load any helper scripts as defined here
 #zpacman_helper=(aur)
+
+

--- a/templates/zlogin
+++ b/templates/zlogin
@@ -1,8 +1,7 @@
-
-
 #
 # User configuration sourced by login shells
 #
 
 # Initialize zim
 [[ -s ${ZIM_HOME}/login_init.zsh ]] && source ${ZIM_HOME}/login_init.zsh
+

--- a/templates/zshrc
+++ b/templates/zshrc
@@ -1,11 +1,10 @@
-
-
 #
 # User configuration sourced by interactive shells
 #
 
-# Change default zim location
+# Define zim location
 export ZIM_HOME=${ZDOTDIR:-${HOME}}/.zim
 
 # Start zim
 [[ -s ${ZIM_HOME}/init.zsh ]] && source ${ZIM_HOME}/init.zsh
+


### PR DESCRIPTION
Update installation instructions in README.md to use cat. Also add blank lines at the end (instead of beginning) of template files, since they're prepended (not appended) to existing files.

See difference of output between print and cat (even zlogin having a blank like at the end):

    % print -rn "$(<zlogin)$(<test)"
    #
    # User configuration sourced by login shells
    #

    # Initialize zim
    [[ -s ${ZIM_HOME}/login_init.zsh ]] && source ${ZIM_HOME}/login_init.zsh# Hello world
    % cat zlogin test
    #
    # User configuration sourced by login shells
    #

    # Initialize zim
    [[ -s ${ZIM_HOME}/login_init.zsh ]] && source ${ZIM_HOME}/login_init.zsh

    # Hello world

Fixes #94. Fixes #280.
