### PR TITLE
Add pikaur to list of AUR helpers that handle SUID

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -24,7 +24,7 @@ elif (( ! ${+commands[${zpacman_frontend}]} )); then
 You can fix this error by editing the 'zpacman_frontend' variable in your .zimrc" >&2
   zpacman_frontend='pacman'
   zpacman_frontend_priv='sudo pacman'
-elif [[ ${zpacman_frontend} == ("yaourt"|"pacaur"|"yay") ]]; then
+elif [[ ${zpacman_frontend} == ("yaourt"|"pacaur"|"yay"|"pikaur") ]]; then
   # those AUR helpers handle SUID themselves
   zpacman_frontend_priv="${zpacman_frontend}"
 else


### PR DESCRIPTION
`pikaur` (https://github.com/actionless/pikaur) handles sudo authentication itself.
