### PR TITLE
[archive] Allow archives in other directories

### DIFF
--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -1,17 +1,17 @@
+# vim:et sts=2 sw=2 ft=zsh
 #
 # Creates archive files
 #
 
 if (( # < 2 )); then
-  print "usage: ${0} [archive_name.ext] [file]..." >&2
+  print "usage: ${0} <archive_name.ext> <file>..." >&2
   return 1
 fi
 
 # we are quitting (above) if there are less than 2 vars,
 # so we don't need any argc check here.
 
-# strip the path, just in case one is provided for some reason
-local archive_name="${1:t}"
+local archive_name="${1}"
 shift
 
 # pigz and pbzip2 are aliased in the init.zsh file. This provides a significant speedup, resulting in a

--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -1,19 +1,14 @@
+# vim:et sts=2 sw=2 ft=zsh
 #
 # Unarchives files
 #
 
 if (( # != 1 )); then
-  print "usage: ${0} [archive.ext]" >&2
+  print "usage: ${0} <archive_name.ext>" >&2
   return 1
 fi
 
-if [[ ! -s ${1} ]]; then
-  print "archive \"${1}\" was not found or has size 0." >&2
-  return 1
-fi
-
-# strip the path, just in case one is provided for some reason
-local archive_name="${1:t}"
+local archive_name="${1}"
 
 # using unpigz/pbunzip2 provides little to decompression time; the benefit is mainly in compression time.
 # setting it as an alias in the init.zsh file should be sufficient here.


### PR DESCRIPTION
Current code will create an archive in the current directory with:

    archive ../test.tar.gz test.*

or will complain that the following archive doesn't exist in the current directory (given it actually exists in the parent one):

    unarchive ../test.tar.gz

Other changes:

* Use `<required_param>` instead of `[required_param]` in the usage text
* Don't explictly check if archive exists in `unarchive`, but let the respective tool fail with its own message
