### PR TITLE
[history] Remove EXTENDED_HISTORY and INC_APPEND_HISTORY

### DIFF
--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -1,26 +1,20 @@
-History
+history
 =======
 
-Sets sane default history options.
+Sets sane history options.
 
-History file is set to save in `${ZDOTDIR:-${HOME}}/.zhistory`
+The history is set to be saved in the `${ZDOTDIR:-${HOME}}/.zhistory` file.
 
-(most likely ~/.zhistory)
-
-Zsh Options
+Zsh options
 -----------
 
-| Option | Effect |
-| ------ | ------ |
-| BANG_HIST | Use csh-style '!' expansion |
-| EXTENDED_HISTORY | Save timestamps along with commands |
-| INC_APPEND_HISTORY | Commands are added to the history file immediately upon execution |
-| SHARE_HISTORY | Causes all terminals to share the same history 'session' |
-| HIST_IGNORE_DUPS | Do not enter immediate duplicates into history |
-| HIST_IGNORE_ALL_DUPS | If duplicate is to be added, remove older instance in history |
-| HIST_IGNORE_SPACE | Do not add any commands to history that begin with a space |
-| HIST_SAVE_NO_DUPS | When saving, older commands that duplicate newer commands are omitted |
-| HIST_VERIFY | Upon history 'selection', don't execute immediately. Require a carriage return |
+  * `BANG_HIST` performs csh-style '!' expansion.
+  * `SHARE_HISTORY` causes all terminals to share the same history 'session'.
+  * `HIST_IGNORE_DUPS` does not enter immediate duplicates into the history.
+  * `HIST_IGNORE_ALL_DUPS` removes older command from the history if a duplicate is to be added.
+  * `HIST_IGNORE_SPACE` removes commands from the history that begin with a space.
+  * `HIST_SAVE_NO_DUPS` ommits older commands that duplicate newer ones when saving.
+  * `HIST_VERIFY` doesn't execute the command directly upon history expansion.
 
 Aliases
 -------

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -2,42 +2,36 @@
 # Configures history options
 #
 
-# sets the location of the history file
+# The file to save the history in.
 HISTFILE="${ZDOTDIR:-${HOME}}/.zhistory"
 
-# limit of history entries
+# The maximum number of events stored in the internal history list and in the history file.
 HISTSIZE=10000
 SAVEHIST=10000
 
 # Perform textual history expansion, csh-style, treating the character ‘!’ specially.
 setopt BANG_HIST
 
-# Save each command’s beginning timestamp (in seconds since the epoch) and the duration (in seconds) to the history file.
-# ‘: <beginning time>:<elapsed seconds>;<command>’.
-setopt EXTENDED_HISTORY
-
-# This options works like APPEND_HISTORY except that new history lines are added to the ${HISTFILE} incrementally
-# (as soon as they are entered), rather than waiting until the shell exits.
-setopt INC_APPEND_HISTORY
-
-# Shares history across all sessions rather than waiting for a new shell invocation to read the history file.
+# This option both imports new commands from the history file, and also causes your
+# typed commands to be appended to the history file (like specifying INC_APPEND_HISTORY).
+# The history lines are also output with timestamps ala EXTENDED_HISTORY.
 setopt SHARE_HISTORY
 
 # Do not enter command lines into the history list if they are duplicates of the previous event.
 setopt HIST_IGNORE_DUPS
 
-# If a new command line being added to the history list duplicates an older one, 
+# If a new command line being added to the history list duplicates an older one,
 # the older command is removed from the list (even if it is not the previous event).
 setopt HIST_IGNORE_ALL_DUPS
 
-# Remove command lines from the history list when the first character on the line is a space,
-# or when one of the expanded aliases contains a leading space.
+# Remove command lines from the history list when the first character on the
+# line is a space, or when one of the expanded aliases contains a leading space.
 setopt HIST_IGNORE_SPACE
 
 # When writing out the history file, older commands that duplicate newer ones are omitted.
 setopt HIST_SAVE_NO_DUPS
 
-# Whenever the user enters a line with history expansion, don’t execute the line directly;
+# Whenever the user enters a line with history expansion, don't execute the line directly;
 # instead, perform history expansion and reload the line into the editing buffer.
 setopt HIST_VERIFY
 

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -37,4 +37,4 @@ setopt HIST_VERIFY
 
 
 # Lists the ten most used commands.
-alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
+alias history-stat="fc -ln 0 | awk '{print \$1}' | sort | uniq -c | sort -nr | head"


### PR DESCRIPTION
as they are not required (not even recommended) to be set along with `SHARE_HISTORY`. See zshoptions(1):

> This option ... also causes your typed commands to be appended to the history file (the latter is like specifying `INC_APPEND_HISTORY`, which should be turned off if this option is in effect). The history lines are also output with timestamps ala `EXTENDED_HISTORY` ...

Also update copy in comments and in the README.

Use `fc -l` instead of `history`, as `fc` is the actual Zsh builtin. Add the `-n` flag to suppress event numbers when listing.