### PR TITLE
Make ls working on osx

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -17,8 +17,10 @@ if (( terminfo[colors] >= 8 )); then
     else
       export LS_COLORS='di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
     fi
-
-    alias ls='ls --group-directories-first --color=auto'
+    # OSX ls doesn't understand group-directories-first and color=auto as valid params
+    if [[ ${OSTYPE} != darwin* ]]; then
+      alias ls='ls --group-directories-first --color=auto'
+    fi
   else
     # BSD
 


### PR DESCRIPTION
# Mac OX :( ls lacks some features

```
➜ .zim master ✓ ls --group-directories-first --color=auto
ls: illegal option -- -
usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]
```
