### PR TITLE
[utility] Don't test colors and smarter "if it's GNU"

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -2,54 +2,57 @@
 # Utility Functions and Options
 #
 
-#
-# Colours
-#
-
-if (( terminfo[colors] >= 8 )); then
+if (( ${+commands[dircolors]} )) && ls --version &>/dev/null; then
+  # GNU
 
   # ls Colours
-  if (( ${+commands[dircolors]} )); then
-    # GNU
-
-    (( ! ${+LS_COLORS} )) && if [[ -s ${HOME}/.dir_colors ]]; then
-      eval "$(dircolors --sh ${HOME}/.dir_colors)"
-    else
-      export LS_COLORS='di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
-    fi
-
-    alias ls='ls --group-directories-first --color=auto'
+  if [[ ${+LS_COLORS} -eq 0 && -s ${HOME}/.dir_colors ]]; then
+    eval "$(dircolors --sh ${HOME}/.dir_colors)"
   else
-    # BSD
-
-    (( ! ${+CLICOLOR} )) && export CLICOLOR=1
-    (( ! ${+LSCOLORS} )) && export LSCOLORS='ExfxcxdxbxGxDxabagacad'
-
-    # stock OpenBSD ls does not support colors at all, but colorls does.
-    if [[ ${OSTYPE} == openbsd* && ${+commands[colorls]} -ne 0 ]]; then
-      alias ls='colorls'
-    fi
+    export LS_COLORS='di=1;34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
   fi
+  alias ls='ls --group-directories-first --color=auto'
+  alias lx='ll -X' # long format, sort by extension
 
-  # grep Colours
-  (( ! ${+GREP_COLOR} )) && export GREP_COLOR='37;45'               #BSD
-  (( ! ${+GREP_COLORS} )) && export GREP_COLORS="mt=${GREP_COLOR}"  #GNU
-  if [[ ${OSTYPE} == openbsd* ]]; then
-    (( ${+commands[ggrep]} )) && alias grep='ggrep --color=auto'
-  else
-   alias grep='grep --color=auto'
-  fi
+  # Always wear a condom
+  alias chmod='chmod --preserve-root -v'
+  alias chown='chown --preserve-root -v'
 
-  # less Colours
-  if [[ ${PAGER} == 'less' ]]; then
-    (( ! ${+LESS_TERMCAP_mb} )) && export LESS_TERMCAP_mb=$'\E[1;31m'   # Begins blinking.
-    (( ! ${+LESS_TERMCAP_md} )) && export LESS_TERMCAP_md=$'\E[1;31m'   # Begins bold.
-    (( ! ${+LESS_TERMCAP_me} )) && export LESS_TERMCAP_me=$'\E[0m'      # Ends mode.
-    (( ! ${+LESS_TERMCAP_se} )) && export LESS_TERMCAP_se=$'\E[0m'      # Ends standout-mode.
-    (( ! ${+LESS_TERMCAP_so} )) && export LESS_TERMCAP_so=$'\E[7m'      # Begins standout-mode.
-    (( ! ${+LESS_TERMCAP_ue} )) && export LESS_TERMCAP_ue=$'\E[0m'      # Ends underline.
-    (( ! ${+LESS_TERMCAP_us} )) && export LESS_TERMCAP_us=$'\E[1;32m'   # Begins underline.
+  # not aliasing rm -i, but if safe-rm is available, use condom.
+  # if safe-rmdir is available, the OS is suse which has its own terrible 'safe-rm' which is not what we want
+  if (( ${+commands[safe-rm]} && ! ${+commands[safe-rmdir]} )); then
+    alias rm='safe-rm'
   fi
+else
+  # BSD
+
+  # ls Colours
+  (( ! ${+CLICOLOR} )) && export CLICOLOR=1
+  (( ! ${+LSCOLORS} )) && export LSCOLORS='ExfxcxdxbxGxDxabagacad'
+  # stock OpenBSD ls does not support colors at all, but colorls does.
+  if [[ ${OSTYPE} == openbsd* && ${+commands[colorls]} -ne 0 ]]; then
+    alias ls='colorls'
+  fi
+fi
+
+# grep Colours
+(( ! ${+GREP_COLOR} )) && export GREP_COLOR='37;45'               #BSD
+(( ! ${+GREP_COLORS} )) && export GREP_COLORS="mt=${GREP_COLOR}"  #GNU
+if [[ ${OSTYPE} == openbsd* ]]; then
+  (( ${+commands[ggrep]} )) && alias grep='ggrep --color=auto'
+else
+ alias grep='grep --color=auto'
+fi
+
+# less Colours
+if [[ ${PAGER} == 'less' ]]; then
+  (( ! ${+LESS_TERMCAP_mb} )) && export LESS_TERMCAP_mb=$'\E[1;31m'   # Begins blinking.
+  (( ! ${+LESS_TERMCAP_md} )) && export LESS_TERMCAP_md=$'\E[1;31m'   # Begins bold.
+  (( ! ${+LESS_TERMCAP_me} )) && export LESS_TERMCAP_me=$'\E[0m'      # Ends mode.
+  (( ! ${+LESS_TERMCAP_se} )) && export LESS_TERMCAP_se=$'\E[0m'      # Ends standout-mode.
+  (( ! ${+LESS_TERMCAP_so} )) && export LESS_TERMCAP_so=$'\E[7m'      # Begins standout-mode.
+  (( ! ${+LESS_TERMCAP_ue} )) && export LESS_TERMCAP_ue=$'\E[0m'      # Ends underline.
+  (( ! ${+LESS_TERMCAP_us} )) && export LESS_TERMCAP_us=$'\E[1;32m'   # Begins underline.
 fi
 
 
@@ -88,24 +91,3 @@ fi
 
 alias df='df -h'
 alias du='du -h'
-
-
-#
-# GNU only
-#
-
-if (( ${+commands[dircolors]} )); then
-
-  alias lx='ll -X' # long format, sort by extension
-
-  # Always wear a condom
-  alias chmod='chmod --preserve-root -v'
-  alias chown='chown --preserve-root -v'
-fi
-
-
-# not aliasing rm -i, but if safe-rm is available, use condom.
-# if safe-rmdir is available, the OS is suse which has its own terrible 'safe-rm' which is not what we want
-if (( ${+commands[safe-rm]} && ! ${+commands[safe-rmdir]} )); then
-  alias rm='safe-rm'
-fi


### PR DESCRIPTION
Looks like most (if not all) others, will report at least `8`. See https://gist.github.com/michael-lazar/4e1beb7be279c72f59662127b5a234e6 (423 different terminals reporting 8, 15, 16, 52, 64, 88, or 256).

To test "if it's GNU", don't just test for the presence of `dircolors`, but also check if `ls` is GNU by accepting the `--version` parameter.

This is being done because MacOS's homebrew allowed installing a mixture of GNU and BSD tools together, where we got the GNU `dircolors`, but the BSD `ls`. See Homebrew/homebrew-core#36241

The homebrew changes were partially reverted in Homebrew/homebrew-core#36494, which does not mix the two tools above anymore, thus not breaking our script anymore either. But I prefer we keep this safer for the future.