### PR TITLE
feat(git): add aliases for merge sign and verify

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -112,9 +112,12 @@ Aliases
 
   * `gm` joins two or more development histories together.
   * `gmC` performs the merge but does not commit.
-  * `gmF` performs the merge generating a commit even if the merge resolved as a
-    fast-forward.
+  * `gmF` performs the merge generating a commit even if the merge resolved as
+    a fast-forward.
   * `gma` aborts the conflict resolution, and reconstructs the pre-merge state.
+  * `gmS` commits with GPG signature.
+  * `gmv` verifies the GPG signature of the tip commit of the side branch being
+    merged.
   * `gmt` runs the merge conflict resolution tools to resolve conflicts.
 
 ### Push

--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -104,11 +104,11 @@ alias glc='git shortlog --summary --numbered'
 
 # Merge (m)
 alias gm='git merge'
+alias gma='git merge --abort'
 alias gmC='git merge --no-commit'
 alias gmF='git merge --no-ff'
 alias gmS='git merge -S'
-alias gmV='git merge --verify-signatures'
-alias gma='git merge --abort'
+alias gmv='git merge --verify-signatures'
 alias gmt='git mergetool'
 
 # Push (p)

--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -106,6 +106,8 @@ alias glc='git shortlog --summary --numbered'
 alias gm='git merge'
 alias gmC='git merge --no-commit'
 alias gmF='git merge --no-ff'
+alias gmS='git merge -S'
+alias gmV='git merge --verify-signatures'
 alias gma='git merge --abort'
 alias gmt='git mergetool'
 


### PR DESCRIPTION
Adds the following aliases:
  - gmS: GPG-sign the resulting merge commit.
  - gmV: Verify that the tip commit of the side branch being merged is
  signed with a valid key, i.e. a key that has a valid uid: in the
  default trust model, this means the signing key has been signed by a
  trusted key. If the tip commit of the side branch is not signed with a
  valid key, the merge is aborted.
