### PR TITLE
Added option to select foreground color for eriner theme

### DIFF
--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -20,10 +20,10 @@ prompt_eriner_help () {
   cat <<EOH
 This prompt is color-scheme-able. You can customize it using:
 
-    prompt eriner [status_color] [pwd_color] [git_clean_color] [git_dirty_color]
+    prompt eriner [status_color] [pwd_color] [git_clean_color] [git_dirty_color] [foreground_color]
 
 where the parameters are the background colors for each segment. The default
-values are black, cyan, green, and yellow.
+values are black, cyan, green, yellow, default
 
 In order for this prompt to render correctly, a font with Powerline symbols is
 required. A simple way to install a font with Powerline symbols is to follow
@@ -35,6 +35,7 @@ prompt_eriner_main() {
   local prompt_eriner_retval=${?}
   local prompt_eriner_color1=${1:-black}
   local prompt_eriner_color2=${2:-cyan}
+  local prompt_eriner_fg=${5:-default}
 
   ### Segment drawing
   # Utility functions to make it easy and re-usable to draw segmented prompts.
@@ -75,7 +76,7 @@ prompt_eriner_main() {
     (( $(jobs -l | wc -l) )) && segment+=' %F{cyan}⚙'
     (( RANGER_LEVEL )) && segment+=' %F{cyan}r'
     if [[ ${USER} != ${DEFAULT_USER} || -n ${SSH_CLIENT} ]]; then
-       segment+=" %F{%(!.yellow.default)}${USER}@%m"
+       segment+=" %F{${prompt_eriner_fg}}${USER}@%m"
     fi
     if [[ -n ${segment} ]]; then
       prompt_eriner_segment ${prompt_eriner_color1} "${segment} "
@@ -123,7 +124,7 @@ prompt_eriner_setup() {
     'prompt' '%b%c%s' \
     'color' '%C%D'
 
-  PS1="\$(prompt_eriner_main ${@:1:2})"
+  PS1="\$(prompt_eriner_main ${@:1:5})"
   RPS1=''
 }
 
@@ -133,7 +134,7 @@ prompt_eriner_preview () {
   else
     prompt_preview_theme eriner
     print
-    prompt_preview_theme eriner black blue green yellow
+    prompt_preview_theme eriner black blue green yellow default
   fi
 }
 


### PR DESCRIPTION
I had a problem with eriner theme. I use dark color mode, and it does not allow me to select black foreground for the status panel. I fixed it and added the option to select the foreground color. 

Usage:
`prompt eriner black blue green yellow black`


Now it looks like this:
<img width="454" alt="Снимок экрана 2019-06-21 в 21 27 33" src="https://user-images.githubusercontent.com/91447/59943628-65b0ae00-946b-11e9-819b-b79bcac5a4af.png">

I think it's also possible to make an automatic switch to black foreground if user has been selected cyan/yellow/red and so on.