### PR TITLE
Verify terminfo before bindkey

### DIFF
--- a/modules/history-substring-search/init.zsh
+++ b/modules/history-substring-search/init.zsh
@@ -11,5 +11,9 @@ bindkey '^[[B' history-substring-search-down
 
 # Bind up and down keys
 zmodload -F zsh/terminfo +p:terminfo
-bindkey "${terminfo[kcuu1]}" history-substring-search-up
-bindkey "${terminfo[kcud1]}" history-substring-search-down
+if [[ "${terminfo[kcuu1]}" != "" ]]; then
+  bindkey "${terminfo[kcuu1]}" history-substring-search-up
+fi
+if [[ "${terminfo[kcud1]}" != "" ]]; then
+  bindkey "${terminfo[kcud1]}" history-substring-search-down
+fi


### PR DESCRIPTION
Check `terminfo` has a value before `bindkey` to prevent errors:

```
[84786]: /Users/xxx/.zim/modules/history-substring-search/init.zsh:bindkey:14: cannot bind to an empty key sequence
[84786]: /Users/xxx/.zim/modules/history-substring-search/init.zsh:bindkey:15: cannot bind to an empty key sequence
```
