### PR TITLE
add .zprofile to the list of startup files

### DIFF
--- a/src/zimfw.zsh.erb
+++ b/src/zimfw.zsh.erb
@@ -5,7 +5,7 @@ class Zim
   def initialize
     @home = "${ZDOTDIR:-${HOME}}"
     @min_zsh_version = "5.2"
-    @startup_files_glob = ".z(shenv|shrc|login|logout)"
+    @startup_files_glob = ".z(shenv|profile|shrc|login|logout)"
     @version = "1.0.0"
     @ellipsis = " ..."
     @okay = "%F{green})%f "


### PR DESCRIPTION
zim does not use/modify `.zprofile` in it's templates.
for completeness/performance the `.zprofile` should be compiled/cleaned if present.

ref: [zsh startup files](http://zsh.sourceforge.net/Intro/intro_3.html)
