### PR TITLE
Add helpfull action when module not installed

### DIFF
--- a/zimfw.zsh
+++ b/zimfw.zsh
@@ -204,7 +204,7 @@ Startup options:
       _zdisableds+=(${zmodule})
     else
       if [[ ! -d ${zdir} ]]; then
-        print -u2 -PR "%F{red}x ${funcfiletrace[1]}:%B${zmodule}:%b Not installed%f"
+        print -u2 -PR "%F{red}x ${funcfiletrace[1]}:%B${zmodule}:%b Not installed |try → zimfw install%f"
         _zfailed=1
         return 1
       fi


### PR DESCRIPTION
I'm not sure how to better format this 'action' but I think it's going to be helpful for anyone starting with zim. This tripped me out when I just switch to new version of zim.